### PR TITLE
adding Chinese China (zh-CN ) as locale

### DIFF
--- a/crunchyroll.go
+++ b/crunchyroll.go
@@ -28,6 +28,7 @@ const (
 	RU         = "ru-RU"
 	AR         = "ar-SA"
 	ME         = "ar-ME"
+	CN         = "zh-CN"
 )
 
 // MediaType represents a media type.

--- a/utils/locale.go
+++ b/utils/locale.go
@@ -19,6 +19,7 @@ var AllLocales = []crunchyroll.LOCALE{
 	crunchyroll.RU,
 	crunchyroll.AR,
 	crunchyroll.ME,
+	crunchyroll.CN,
 }
 
 // ValidateLocale validates if the given locale actually exist.
@@ -56,6 +57,8 @@ func LocaleLanguage(locale crunchyroll.LOCALE) string {
 		return "Russian"
 	case crunchyroll.AR, crunchyroll.ME:
 		return "Arabic"
+	case crunchyroll.CN:
+		return "Chinese (China)"
 	default:
 		return ""
 	}


### PR DESCRIPTION
https://beta.crunchyroll.com/de/series/GZJH3DJ8E/the-daily-life-of-the-immortal-king

Crunchyroll has recently added anime with the Chinese language. 
Therefore I have added the locale for it

```
➞ Downloading episode `Grande Dame vs Grande Dame` to `Grande Dame vs Grande Dame.mkv` (merging audio for additional formats)
➞       Episode: S03E01
➞       Audio: zh-CN
➞       Subtitle: 
➞       Resolution: 1920x1080px
➞       FPS: 24.00
```


```
Audio
ID                                       : 2
Format                                   : AAC LC
Format/Info                              : Advanced Audio Codec Low Complexity
Codec-ID                                 : A_AAC-2
Dauer                                    : 20 min 4s
Kanäle                                   : 2 Kanäle
Channel layout                           : L R
Samplingrate                             : 44,1 kHz
Bildwiederholungsrate                    : 43,066 FPS (1024 SPF)
Compression mode                         : Lossy
Titel                                    : Chinese China
Sprache                                  : Chinesisch (CN)
Default                                  : Nein
Forced                                   : Nein
```